### PR TITLE
Chemed fail: bad SMILES

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,5 +1,8 @@
 Change Log
 ==========
+v0.3.2 (2021-09-02)
+-------------------
+* Added SMILES sanitization before generating sample space 
 
 v0.3.1 (2021-08-26)
 -------------------

--- a/exmol/exmol.py
+++ b/exmol/exmol.py
@@ -242,7 +242,8 @@ def sample_space(
 
         def batched_f(sm, se):
             return np.array([f(smi, sei) for smi, sei in zip(sm, se)])
-
+    
+    origin_smiles = stoned.sanitize_smiles(origin_smiles)[1]
     smi_yhat = batched_f([origin_smiles], [sf.encoder(origin_smiles)])
     try:
         iter(smi_yhat)

--- a/tests/test_exmol.py
+++ b/tests/test_exmol.py
@@ -1,7 +1,7 @@
 import exmol
 from rdkit.Chem import MolFromSmiles as smi2mol
 from rdkit.Chem import MolToSmiles as mol2smi
-
+import selfies as sf
 
 def test_version():
     assert exmol.__version__

--- a/tests/test_exmol.py
+++ b/tests/test_exmol.py
@@ -147,3 +147,15 @@ def test_compare_img():
     m2 = smi2mol(smi2)
     r, _ = exmol.moldiff(m1, m2)
     assert len(r) > 0
+
+def test_corrupt_smiles():
+    badsmi = 'C/C=C/C(=O)C1CCC(C=C1C)(C)C'
+    badchars = exmol.stoned.get_selfie_chars(sf.encoder(badsmi))
+    basic = exmol.get_basic_alphabet()
+  
+    if len(list(set(badchars)-set(basic))) != 0:
+        goodsmi = exmol.stoned.sanitize_smiles(badsmi)[1]
+        goodchars = exmol.stoned.get_selfie_chars(sf.encoder(goodsmi))
+    
+    assert len(list(set(goodchars)-set(basic))) == 0
+    

--- a/tests/test_exmol.py
+++ b/tests/test_exmol.py
@@ -149,13 +149,11 @@ def test_compare_img():
     assert len(r) > 0
 
 def test_corrupt_smiles():
+    def model(s, se):
+        return int("N" in s)
+
     badsmi = 'C/C=C/C(=O)C1CCC(C=C1C)(C)C'
-    badchars = exmol.stoned.get_selfie_chars(sf.encoder(badsmi))
-    basic = exmol.get_basic_alphabet()
-  
-    if len(list(set(badchars)-set(basic))) != 0:
-        goodsmi = exmol.stoned.sanitize_smiles(badsmi)[1]
-        goodchars = exmol.stoned.get_selfie_chars(sf.encoder(goodsmi))
+    explanation = exmol.sample_space(badsmi, model, preset="narrow", batched=False)      
+    assert ~np.isnan(explanation[0].yhat)
     
-    assert len(list(set(goodchars)-set(basic))) == 0
-    
+

--- a/tests/test_exmol.py
+++ b/tests/test_exmol.py
@@ -2,6 +2,7 @@ import exmol
 from rdkit.Chem import MolFromSmiles as smi2mol
 from rdkit.Chem import MolToSmiles as mol2smi
 import selfies as sf
+import numpy as np
 
 def test_version():
     assert exmol.__version__


### PR DESCRIPTION
Addresses issue #32 
 Chemed was failing because 'C/C=C/C(=O)C1CCC(C=C1C)(C)C' was bad. Sanitize the molecule first. See new test. 