### PR TITLE
Refactored to use skunk

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ v0.4.0
 -------------------
 * Refactored code into files
 * Added SVG rewrite so mol structures are SVGs
+* SVGs are handled with skunks
 
 
 v0.3.2 (2021-09-02)

--- a/exmol/plot_utils.py
+++ b/exmol/plot_utils.py
@@ -11,6 +11,7 @@ import rdkit.Chem
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 from .data import *
+import skunk
 
 delete_color = mpl.colors.to_rgb("#F06060")
 modify_color = mpl.colors.to_rgb("#1BBC9B")
@@ -30,46 +31,6 @@ def _extract_loc(e):
     return min(x), min(y), max(x) - min(x), max(y) - min(y)
 
 
-def rewrite_svg(svg, rdict):
-    ns = "http://www.w3.org/2000/svg"
-    root, idmap = ET.XMLID(svg)
-    parent_map = {c: p for p in root.iter() for c in p}
-    for rk, rvtup in rdict.items():
-        rv, size = rvtup
-        if rk in idmap:
-            e = idmap[rk]
-            # try to use id width/height
-            # case when we have image
-            if 'width' in e.attrib:
-                x, y = e.attrib['x'], -float(e.attrib['y'])
-                # make new node
-                # to hold things
-                new_e = ET.SubElement(
-                    parent_map[e], f'{{{ns}}}g', {'id': f'{rk}-g'})
-                parent_map[e].remove(e)
-                dx, dy = float(e.attrib['width']), float(e.attrib['height'])
-                #dx, dy = size
-                e = new_e
-            else:
-                # relying on there being a path object inside to give clue
-                # to size
-                c = list(e)[0]
-                x, y, dx, dy = _extract_loc(c)
-                e.remove(c)
-            # set attributes on SVG so loc and width/height are correct
-            rr = ET.fromstring(rv)
-            rr.attrib['x'] = str(x)
-            rr.attrib['y'] = str(y)
-            rr.attrib['width'] = str(dx)
-            rr.attrib['height'] = str(dy)
-            e.insert(0, rr)
-        else:
-            print('Warning, could not find', rk)
-            print(list(idmap.keys()))
-    ET.register_namespace("", ns)
-    return ET.tostring(root, encoding="unicode", method='xml')
-
-
 def insert_svg(exps: List[Example],
                mol_size: Tuple[int, int] = (200, 200)) -> str:
     """Replace rasterized image files with SVG versions of molecules
@@ -80,15 +41,9 @@ def insert_svg(exps: List[Example],
     """
     size = mol_size
     mol_svgs = _mol_images(exps, mol_size, 12, True)
-    svg = mpl2svg(bbox_inches='tight')
-    rewrites = {f'rdkit-img-{i}': (v, size) for i, v in enumerate(mol_svgs)}
-    return rewrite_svg(svg, rewrites)
-
-
-def mpl2svg(**kwargs):
-    with io.BytesIO() as output:
-        plt.savefig(output, format='svg', **kwargs)
-        return output.getvalue()
+    svg = skunk.pltsvg(bbox_inches="tight")
+    rewrites = {f'rdkit-img-{i}': v for i, v in enumerate(mol_svgs)}
+    return skunk.insert(rewrites, svg=svg)
 
 
 def trim(im):
@@ -125,7 +80,7 @@ def _image_scatter(x, y, imgs, subtitles, colors, ax, offset):
         # TODO Figure out how to put this back
         #im = trim(im)
         img_data = np.asarray(im)
-        img_box = OffsetImage(img_data)
+        img_box = skunk.ImageBox(f'rdkit-img-{i}', img_data)
         title_box = TextArea(t)
         packed = VPacker(children=[img_box, title_box],
                          pad=0, sep=4, align="center")
@@ -140,9 +95,6 @@ def _image_scatter(x, y, imgs, subtitles, colors, ax, offset):
             bboxprops=dict(edgecolor=c),
         )
         ax.add_artist(bb)
-
-        # add gid in case svg-rewrite
-        img_box.properties()['children'][0].set_gid(f'rdkit-img-{i}')
 
         bbs.append(bb)
     return bbs

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license="MIT",
     packages=["exmol", "exmol.stoned"],
     install_requires=["selfies", "numpy", "requests", "tqdm", "ratelimit",
-                      "rdkit-pypi", "matplotlib", "scikit-learn", "skunk"],
+                      "rdkit-pypi", "matplotlib", "scikit-learn", "skunk >= 0.4.0"],
     test_suite="tests",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license="MIT",
     packages=["exmol", "exmol.stoned"],
     install_requires=["selfies", "numpy", "requests", "tqdm", "ratelimit",
-                      "rdkit-pypi", "matplotlib", "scikit-learn"],
+                      "rdkit-pypi", "matplotlib", "scikit-learn", "skunk"],
     test_suite="tests",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -6,62 +6,6 @@ import exmol
 import io
 
 
-def draw_svg(mol, width=300, height=300):
-    drawer = Chem.Draw.rdMolDraw2D.MolDraw2DSVG(width, height)
-    drawer.drawOptions().bgColor = None
-    drawer.DrawMolecule(mol)
-    drawer.FinishDrawing()
-    svg = drawer.GetDrawingText()
-    return svg
-
-
-def test_replace_svg():
-    from matplotlib.patches import Rectangle
-    from matplotlib.offsetbox import (DrawingArea,
-                                      AnnotationBbox)
-    mol = Chem.MolFromSmiles(
-        'O=C(NCC1CCCCC1N)C2=CC=CC=C2C3=CC=C(F)C=C3C(=O)NC4CCCCC4')
-    msvg = draw_svg(mol, 300, 300)
-
-    fig, ax = plt.subplots()
-    p = Rectangle((0, 0), 50, 50)
-    offsetbox = DrawingArea(50, 50)
-    offsetbox.add_artist(p)
-
-    ab = AnnotationBbox(offsetbox, (0.5, 0.5))
-
-    ax.add_artist(ab)
-    p.set_gid('offset_box_0')
-
-    svg = exmol.plot_utils.mpl2svg()
-    svg = exmol.plot_utils.rewrite_svg(
-        svg, {'offset_box_0': (msvg, (300, 300))})
-
-
-def test_replace_svg_img():
-    from rdkit.Chem.Draw import MolToImage as mol2img
-    from matplotlib.patches import Rectangle
-    from matplotlib.offsetbox import (OffsetImage,
-                                      AnnotationBbox)
-    mol = Chem.MolFromSmiles(
-        'O=C(NCC1CCCCC1N)C2=CC=CC=C2C3=CC=C(F)C=C3C(=O)NC4CCCCC4')
-    msvg = draw_svg(mol, 300, 300)
-    img = mol2img(mol, width=300, height=300)
-
-    fig, ax = plt.subplots()
-    offsetbox = OffsetImage(img, zoom=50 / 300)
-
-    ab = AnnotationBbox(offsetbox, (0.5, 0.5))
-
-    ax.add_artist(ab)
-    # differrent for images
-    offsetbox.properties()['children'][0].set_gid('offset_box_0')
-
-    svg = exmol.plot_utils.mpl2svg()
-    svg = exmol.plot_utils.rewrite_svg(
-        svg, {'offset_box_0': (msvg, (300, 300))})
-
-
 def test_insert_svg():
     def model(s, se):
         return int("N" in s)
@@ -71,6 +15,8 @@ def test_insert_svg():
     exmol.plot_cf(exps)
     exmol.plot_space(samples, exps)
     svg = exmol.insert_svg(exps)
+    with open('test-space.svg', 'w') as f:
+        f.write(svg)
 
 
 def test_insert_svg_long():
@@ -83,6 +29,8 @@ def test_insert_svg_long():
     exmol.plot_cf(exps)
     exmol.plot_space(samples, exps, mol_size=(300, 200))
     svg = exmol.insert_svg(exps, mol_size=(300, 200))
+    with open('test-long.svg', 'w') as f:
+        f.write(svg)
 
 
 def test_insert_svg_grid():
@@ -94,5 +42,5 @@ def test_insert_svg_grid():
     exps = exmol.cf_explain(samples, 3)
     exmol.plot_cf(exps)
     svg = exmol.insert_svg(exps)
-    # with open('test.svg', 'w') as f:
-    #     f.write(svg)
+    with open('test-cf.svg', 'w') as f:
+        f.write(svg)


### PR DESCRIPTION
This removed code duplicated with `skunk`. Using `skunk` also enables `skunk.display` to show SVGs in Jupyter Notebooks, which was currently impossible. 