### PR TITLE
Added docs on using custom surrogate models

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ It is also possible to get global attributions for multiple base molecules. For 
 beta = exmol.lime_explain(joint_space, descriptor_type='ECFP', return_beta=True, multiple_bases=True)
 ```
 
-`lime_explain()` uses a linear surrogate model for descriptor explanations. You can also use a custom surrogate model instead of a linear model. To do so, just add desired descriptors to the chemical space using the `add_descriptors()` function and then use a custom model on samples to get explanations. For example, add ECFP descriptors using `exmol.add_descriptors(samples, descriptor_type='ECFP')`. 
+`lime_explain()` uses a linear surrogate model for descriptor explanations. You can also use a custom surrogate model instead of a linear model. To do so, just add desired descriptors to the chemical space using the `add_descriptors()` function and then use a custom model on samples to get explanations. For example, add ECFP descriptors using `exmol.add_descriptors(samples, descriptor_type='ECFP')`.
 
 ## Further Examples
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ It is also possible to get global attributions for multiple base molecules. For 
 beta = exmol.lime_explain(joint_space, descriptor_type='ECFP', return_beta=True, multiple_bases=True)
 ```
 
+`lime_explain()` uses a linear surrogate model for descriptor explanations. You can also use a custom surrogate model instead of a linear model. To do so, just add desired descriptors to the chemical space using `exmol.add_descriptors(samples, descriptor_type)` and then use a custom model on samples to get explanations.
+
 ## Further Examples
 
 You can find more examples by looking at the exact code used to generate all figures from our paper [in the docs webpage](https://ur-whitelab.github.io/exmol/toc.html).

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ It is also possible to get global attributions for multiple base molecules. For 
 beta = exmol.lime_explain(joint_space, descriptor_type='ECFP', return_beta=True, multiple_bases=True)
 ```
 
-`lime_explain()` uses a linear surrogate model for descriptor explanations. You can also use a custom surrogate model instead of a linear model. To do so, just add desired descriptors to the chemical space using `exmol.add_descriptors(samples, descriptor_type)` and then use a custom model on samples to get explanations.
+`lime_explain()` uses a linear surrogate model for descriptor explanations. You can also use a custom surrogate model instead of a linear model. To do so, just add desired descriptors to the chemical space using the `add_descriptors()` function and then use a custom model on samples to get explanations. For example, add ECFP descriptors using `exmol.add_descriptors(samples, descriptor_type='ECFP')`. 
 
 ## Further Examples
 

--- a/exmol/plot_utils.py
+++ b/exmol/plot_utils.py
@@ -278,7 +278,7 @@ def plot_space_by_fit(
     if ax is None:
         ax = plt.figure(**figure_kwargs).gca()
 
-    yhat = [e.yhat for e in examples]
+    yhat = np.array([e.yhat for e in examples])
     yhat -= np.mean(yhat)
     x_mat = np.array([list(e.descriptors.descriptors) for e in examples]).reshape(
         len(examples), -1


### PR DESCRIPTION
Addresses #109 
- [ ] Add the ability to use custom models instead of `lime_explain` (and/or descriptors)