### PR TITLE
Update run_chemed

### DIFF
--- a/exmol/exmol.py
+++ b/exmol/exmol.py
@@ -555,6 +555,7 @@ def run_chemed(
     similarity: float = 0.1,
     fp_type: str = "ECFP4",
     _pbar: Any = None,
+    smi_name : str = "ConnectivitySMILES"
 ) -> Tuple[List[str], List[float]]:
     """
     This method is similar to STONED but works by quering PubChem
@@ -584,7 +585,7 @@ def run_chemed(
         data = reply.json()
     except:
         return [], []
-    smiles = [d["CanonicalSMILES"] for d in data["PropertyTable"]["Properties"]]
+    smiles = [d[smi_name] for d in data["PropertyTable"]["Properties"]]
     smiles = list(set(smiles))
 
     if _pbar:


### PR DESCRIPTION
The run_chemed function became redundant when the returned name for the SMILES value changed to ConnectivitySMILES, an argument has been added to reflect this and set the standard name to "ConnectivitySMILES"